### PR TITLE
Fix build font error when setting value of "tempPath" without "tmp".

### DIFF
--- a/FontPruner.py
+++ b/FontPruner.py
@@ -43,7 +43,7 @@ def bulidNewFont(originPath,outPutPath):
       fontName = fontOrigin[-index:]
       print ("fontName" +fontName)
       fullPara = ""
-      fullPara += TempPathDefault+SepPath+IntermediateFolder+SepPath+ChineseOutPut+"  "+TempPathDefault+SepPath+IntermediateFolder+SepPath+UnChineseOutPut+" "+fontOrigin + " " + fullOutPut+SepPath+fontName 
+      fullPara += outPutPath+SepPath+IntermediateFolder+SepPath+ChineseOutPut+"  "+outPutPath+SepPath+IntermediateFolder+SepPath+UnChineseOutPut+" "+fontOrigin + " " + fullOutPut+SepPath+fontName 
       command ="java -jar bin"+SepPath+"sfnttool.jar -c " +fullPara
       
       if os.system(command) is not Succ:


### PR DESCRIPTION
For example, if we run command:
`FontPruner.py --inputPath=text --inputFont=input.ttf --tempPath=result`
We always got error:

> extracted file :tmp\intermediate\ChineseOutPut.txt
extracted file :tmp\intermediate\unChineseOutPut.txt
文本不存在或者无效tmp\intermediate\ChineseOutPut.txt
文本不存在或者无效tmp\intermediate\unChineseOutPut.txt

funtion `bulidNewFont` uses `TempPathDefault` whose value is `"tmp"` instead of `outPutPath` which is the passed-in parameter for "Temp Path".